### PR TITLE
Add support for ext4fs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_run:
+    workflows: ["Download musl toolchain"]
+    types:
+      - completed
 
 jobs:
   clippy:
@@ -20,6 +26,9 @@ jobs:
         components: rust-src, clippy, rustfmt
         targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat, loongarch64-unknown-none
     - uses: Swatinem/rust-cache@v2
+    - uses: ./.github/workflows/actions/setup-musl
+      with:
+        arch: ${{ matrix.arch }}
     - name: Check rust version
       run: rustc --version --verbose
     - name: Check code format

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,12 @@
 name: Build & Deploy docs
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_run:
+    workflows: ["Download musl toolchain"]
+    types:
+      - completed
 
 env:
   rust-toolchain: nightly-2024-12-25
@@ -20,6 +26,9 @@ jobs:
       with:
         toolchain: ${{ env.rust-toolchain }}
     - uses: Swatinem/rust-cache@v2
+    - uses: ./.github/workflows/actions/setup-musl
+      with:
+        arch: x86_64
     - name: Build docs
       continue-on-error: ${{ github.ref != env.default-branch && github.event_name != 'pull_request' }}
       run: make doc_check_missing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "axruntime",
  "axsync",
  "axtask",
- "bindgen",
+ "bindgen 0.69.5",
  "ctor_bare",
  "flatten_objects",
  "lazy_static",
@@ -187,7 +187,7 @@ dependencies = [
 [[package]]
 name = "arm_gicv2"
 version = "0.1.0"
-source = "git+https://github.com/arceos-hypervisor/arm_gicv2#dfe5f164b94cdd07081c2fe74a0cfe4bef2852c9"
+source = "git+https://github.com/arceos-hypervisor/arm_gicv2#eee14941d490719f6689e82f9a87caea6767bdc3"
 dependencies = [
  "tock-registers 0.8.1",
 ]
@@ -263,7 +263,7 @@ dependencies = [
  "axconfig-gen",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -412,6 +412,7 @@ dependencies = [
  "fatfs",
  "lazyinit",
  "log",
+ "lwext4_rust",
 ]
 
 [[package]]
@@ -443,7 +444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2314ebe07a2fef7b1c1a7d15ab817941cd306ace651bb50024b5a8b3e8485359"
 dependencies = [
  "axerrno",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "log",
 ]
 
@@ -458,7 +459,7 @@ dependencies = [
  "axalloc",
  "axconfig",
  "axlog",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "cortex-a",
  "crate_interface",
@@ -476,7 +477,7 @@ dependencies = [
  "page_table_entry",
  "page_table_multiarch",
  "percpu",
- "raw-cpuid 11.4.0",
+ "raw-cpuid 11.5.0",
  "riscv",
  "riscv_goldfish",
  "sbi-rt",
@@ -490,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "axio"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ca9c10ea4cd42bda87a2abde281fb481c76a0b05976fd03697385ea65d5122"
+checksum = "30aa258a37c25c5e9d3ff45ec80e728ff7c499586e3e40719daf7908f10fd5bd"
 dependencies = [
  "axerrno",
 ]
@@ -505,7 +506,7 @@ dependencies = [
  "axerrno",
  "axfeat",
  "axio",
- "bindgen",
+ "bindgen 0.69.5",
 ]
 
 [[package]]
@@ -648,10 +649,10 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -659,10 +660,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.98",
+ "syn 2.0.101",
  "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -685,9 +706,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitmap-allocator"
@@ -728,14 +749,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9b24894fa5f73bbf9c72196e7f495a1f81d6218a548280a09ada4a937157692"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "shlex",
 ]
@@ -757,9 +778,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -782,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -792,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -804,14 +825,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -870,7 +891,7 @@ checksum = "70272a03a2cef15589bac05d3d15c023752f5f8f2da8be977d983a9d9e6250fb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -896,14 +917,23 @@ checksum = "9a49d5cd78b1c748184d41407b14a58af8403c13328ff2b9f49b0a418c24e3ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "defmt"
-version = "0.3.10"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f6162c53f659f65d00619fe31f14556a6e9f8752ccc4a41bd177ffcf3d6130"
+checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "defmt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -911,22 +941,22 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "0.4.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d135dd939bad62d7490b0002602d35b358dce5fd9233a709d3c1ef467d4bde6"
+checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
 dependencies = [
  "defmt-parser",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "defmt-parser"
-version = "0.4.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3983b127f13995e68c1e29071e5d115cd96f215ccb5e6812e3728cd6f92653b3"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror",
 ]
@@ -942,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedded-hal"
@@ -960,9 +990,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys",
@@ -973,15 +1003,15 @@ name = "fatfs"
 version = "0.4.0"
 source = "git+https://github.com/rafalh/rust-fatfs?rev=85f06e0#85f06e08edbd3368e1b0562f2fc1b6d178bf7b8a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "log",
 ]
 
 [[package]]
 name = "flatten_objects"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a44a8ee8095192119780ad867a02cfb86c44f3cebd16b7161d84e1fb8e26482"
+checksum = "e362dae0b64fc12551b655a09484a643461a283a078fb8a9686d1f58fa46df9a"
 dependencies = [
  "bitmaps",
 ]
@@ -998,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1030,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heapless"
@@ -1064,14 +1094,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -1087,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1112,6 +1143,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1181,18 +1221,18 @@ checksum = "3861aac8febbb038673bf945ee47ac67940ca741b94d1bb3ff6066af2a181338"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -1202,22 +1242,22 @@ source = "git+https://github.com/arceos-org/linked_list.git?tag=v0.1.0#34c8db301
 
 [[package]]
 name = "linkme"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566336154b9e58a4f055f6dd4cbab62c7dc0826ce3c0a04e63b2d2ecd784cdae"
+checksum = "a1b1703c00b2a6a70738920544aa51652532cacddfec2e162d2e29eae01e665c"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbe595006d355eaf9ae11db92707d4338cd2384d16866131cc1afdbdd35d8d9"
+checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1244,12 +1284,21 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "loongArch64"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd48200d465466664e4e899b204b77b5447d60b1ababdad3a2c49ae85417b552"
+checksum = "7c9f0d275c70310e2a9d2fc23250c5ac826a73fa828a5f256401f85c5c554283"
 dependencies = [
  "bit_field",
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "lwext4_rust"
+version = "0.2.0"
+source = "git+https://github.com/Josen-B/lwext4_rust.git#5024eeebbe4859538e5802f8f719fafdc69c476c"
+dependencies = [
+ "bindgen 0.71.1",
+ "log",
 ]
 
 [[package]]
@@ -1266,15 +1315,15 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memory_addr"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f769efcf10b9dfb4c913bebb409cda77b1a3f072b249bf5465e250bcb30eb49"
+checksum = "5438b8df0f13e16e1f46140de247695a95952a5a4479e47197a8711bf1063373"
 
 [[package]]
 name = "memory_set"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335675b7ab07460f532d3b2b557313be73037fdf81b65464d8c0d8bd90d2fbf9"
+checksum = "a4552d02c866c57e8b06b919ea8c2f8f398cad245b8f6aac726657bc972d663d"
 dependencies = [
  "memory_addr",
 ]
@@ -1312,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "page_table_entry"
@@ -1323,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c097d641745a066856a26eed6e486d4430bb3e32c94f1203ea09c63239b360a0"
 dependencies = [
  "aarch64-cpu 10.0.0",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "memory_addr",
  "x86_64 0.15.2",
 ]
@@ -1368,26 +1417,26 @@ checksum = "8a9f4cc54a2e471ff72f1499461ba381ad4eae9cbd60d29c258545b995e406e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1409,23 +1458,23 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1471,11 +1520,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.4.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529468c1335c1c03919960dfefdb1b3648858c20d7ec2d0663e728e4a717efbc"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1528,7 +1577,7 @@ checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1562,6 +1611,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,7 +1631,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1585,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "sbi-rt"
@@ -1620,9 +1675,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "shlex"
@@ -1646,7 +1701,7 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
- "defmt",
+ "defmt 0.3.100",
  "heapless",
  "log",
  "managed",
@@ -1705,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1716,22 +1771,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1754,26 +1809,33 @@ checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.17"
+name = "toml_write"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -1793,9 +1855,9 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa40e09453618c7a927c08c5a990497a2954da7c2aaa6c65e0d4f0fc975f6114"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "log",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1844,7 +1906,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1866,7 +1928,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1894,18 +1956,62 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1913,7 +2019,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1922,14 +2028,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1939,10 +2061,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1951,10 +2085,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1963,10 +2109,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1975,16 +2133,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.3"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -2020,7 +2190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c101112411baafbb4bf8d33e4c4a80ab5b02d74d2612331c61e8192fc9710491"
 dependencies = [
  "bit_field",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "rustversion",
  "volatile 0.4.6",
 ]
@@ -2032,7 +2202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
 dependencies = [
  "bit_field",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "rustversion",
  "volatile 0.4.6",
 ]
@@ -2054,7 +2224,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -2065,5 +2244,16 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]

--- a/api/arceos_api/Cargo.toml
+++ b/api/arceos_api/Cargo.toml
@@ -22,6 +22,8 @@ net = ["dep:axnet", "dep:axdriver", "axfeat/net"]
 display = ["dep:axdisplay", "dep:axdriver", "axfeat/display"]
 
 myfs = ["axfeat/myfs"]
+ext4fs = ["axfeat/ext4fs"]
+fatfs = ["axfeat/fatfs"]
 
 # Use dummy functions if the feature is not enabled
 dummy-if-not-enabled = []

--- a/api/axfeat/Cargo.toml
+++ b/api/axfeat/Cargo.toml
@@ -41,6 +41,8 @@ sched_cfs = ["axtask/sched_cfs", "irq"]
 # File system
 fs = ["alloc", "paging", "axdriver/virtio-blk", "dep:axfs", "axruntime/fs"] # TODO: try to remove "paging"
 myfs = ["axfs?/myfs"]
+ext4fs = ["axfs?/ext4fs"]
+fatfs = ["axfs?/fatfs"]
 
 # Networking
 net = ["alloc", "paging", "axdriver/virtio-net", "dep:axnet", "axruntime/net"]

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -14,6 +14,7 @@ devfs = ["dep:axfs_devfs"]
 ramfs = ["dep:axfs_ramfs"]
 procfs = ["dep:axfs_ramfs"]
 sysfs = ["dep:axfs_ramfs"]
+ext4fs = ["dep:lwext4_rust"]
 fatfs = ["dep:fatfs"]
 myfs = ["dep:crate_interface"]
 use-ramdisk = []
@@ -33,6 +34,7 @@ axfs_ramfs = { version = "0.1", optional = true }
 crate_interface = { version = "0.1", optional = true }
 axsync = { workspace = true }
 axdriver = { workspace = true, features = ["block"] }
+lwext4_rust = { git = "https://github.com/Josen-B/lwext4_rust.git", optional = true }
 axdriver_block = { git = "https://github.com/arceos-org/axdriver_crates.git", tag = "v0.1.2" }
 axns = { workspace = true }
 

--- a/modules/axfs/src/fs/ext4fs.rs
+++ b/modules/axfs/src/fs/ext4fs.rs
@@ -1,0 +1,408 @@
+use crate::alloc::string::String;
+use alloc::sync::Arc;
+use axerrno::AxError;
+use axfs_vfs::{VfsDirEntry, VfsError, VfsNodePerm, VfsResult};
+use axfs_vfs::{VfsNodeAttr, VfsNodeOps, VfsNodeRef, VfsNodeType, VfsOps};
+use axsync::Mutex;
+use lwext4_rust::bindings::{
+    O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY, SEEK_CUR, SEEK_END, SEEK_SET,
+};
+use lwext4_rust::{Ext4BlockWrapper, Ext4File, InodeTypes, KernelDevOp};
+
+use crate::dev::Disk;
+pub const BLOCK_SIZE: usize = 512;
+
+#[allow(dead_code)]
+pub struct Ext4FileSystem {
+    inner: Ext4BlockWrapper<Disk>,
+    root: VfsNodeRef,
+}
+
+unsafe impl Sync for Ext4FileSystem {}
+unsafe impl Send for Ext4FileSystem {}
+
+impl Ext4FileSystem {
+    #[cfg(feature = "use-ramdisk")]
+    pub fn new(mut disk: Disk) -> Self {
+        unimplemented!()
+    }
+
+    #[cfg(not(feature = "use-ramdisk"))]
+    pub fn new(disk: Disk) -> Self {
+        info!(
+            "Got Disk size:{}, position:{}",
+            disk.size(),
+            disk.position()
+        );
+        let inner =
+            Ext4BlockWrapper::<Disk>::new(disk).expect("failed to initialize EXT4 filesystem");
+        let root = Arc::new(FileWrapper::new("/", InodeTypes::EXT4_DE_DIR));
+        Self { inner, root }
+    }
+}
+
+/// The [`VfsOps`] trait provides operations on a filesystem.
+impl VfsOps for Ext4FileSystem {
+    // mount()
+
+    fn root_dir(&self) -> VfsNodeRef {
+        debug!("Get root_dir");
+        //let root_dir = unsafe { (*self.root.get()).as_ref().unwrap() };
+        Arc::clone(&self.root)
+    }
+}
+
+pub struct FileWrapper(Mutex<Ext4File>);
+
+unsafe impl Send for FileWrapper {}
+unsafe impl Sync for FileWrapper {}
+
+impl FileWrapper {
+    fn new(path: &str, types: InodeTypes) -> Self {
+        info!("FileWrapper new {:?} {}", types, path);
+        //file.file_read_test("/test/test.txt", &mut buf);
+
+        Self(Mutex::new(Ext4File::new(path, types)))
+    }
+
+    fn path_deal_with(&self, path: &str) -> String {
+        if path.starts_with('/') {
+            warn!("path_deal_with: {}", path);
+        }
+        let p = path.trim_matches('/');
+        if p.is_empty() || p == "." {
+            return String::new();
+        }
+
+        if let Some(rest) = p.strip_prefix("./") {
+            //if starts with "./"
+            return self.path_deal_with(rest);
+        }
+        let rest_p = p.replace("//", "/");
+        if p != rest_p {
+            return self.path_deal_with(&rest_p);
+        }
+
+        let file = self.0.lock();
+        let path = file.get_path();
+        let fpath = String::from(path.to_str().unwrap().trim_end_matches('/')) + "/" + p;
+        info!("dealt with full path: {}", fpath.as_str());
+        fpath
+    }
+}
+
+/// The [`VfsNodeOps`] trait provides operations on a file or a directory.
+impl VfsNodeOps for FileWrapper {
+    fn get_attr(&self) -> VfsResult<VfsNodeAttr> {
+        let mut file = self.0.lock();
+
+        let perm = file.file_mode_get().unwrap_or(0o755);
+        let perm = VfsNodePerm::from_bits_truncate((perm as u16) & 0o777);
+
+        let vtype = file.file_type_get();
+        let vtype = match vtype {
+            InodeTypes::EXT4_INODE_MODE_FIFO => VfsNodeType::Fifo,
+            InodeTypes::EXT4_INODE_MODE_CHARDEV => VfsNodeType::CharDevice,
+            InodeTypes::EXT4_INODE_MODE_DIRECTORY => VfsNodeType::Dir,
+            InodeTypes::EXT4_INODE_MODE_BLOCKDEV => VfsNodeType::BlockDevice,
+            InodeTypes::EXT4_INODE_MODE_FILE => VfsNodeType::File,
+            InodeTypes::EXT4_INODE_MODE_SOFTLINK => VfsNodeType::SymLink,
+            InodeTypes::EXT4_INODE_MODE_SOCKET => VfsNodeType::Socket,
+            _ => {
+                warn!("unknown file type: {:?}", vtype);
+                VfsNodeType::File
+            }
+        };
+
+        let size = if vtype == VfsNodeType::File {
+            let path = file.get_path();
+            let path = path.to_str().unwrap();
+            file.file_open(path, O_RDONLY)
+                .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+            let fsize = file.file_size();
+            let _ = file.file_close();
+            fsize
+        } else {
+            0
+        };
+        let blocks = (size + (BLOCK_SIZE as u64 - 1)) / BLOCK_SIZE as u64;
+
+        info!(
+            "get_attr of {:?} {:?}, size: {}, blocks: {}",
+            vtype,
+            file.get_path(),
+            size,
+            blocks
+        );
+
+        Ok(VfsNodeAttr::new(perm, vtype, size, blocks))
+    }
+
+    fn create(&self, path: &str, ty: VfsNodeType) -> VfsResult {
+        info!("create {:?} on Ext4fs: {}", ty, path);
+        let fpath = self.path_deal_with(path);
+        let fpath = fpath.as_str();
+        if fpath.is_empty() {
+            return Ok(());
+        }
+
+        let types = match ty {
+            VfsNodeType::Fifo => InodeTypes::EXT4_DE_FIFO,
+            VfsNodeType::CharDevice => InodeTypes::EXT4_DE_CHRDEV,
+            VfsNodeType::Dir => InodeTypes::EXT4_DE_DIR,
+            VfsNodeType::BlockDevice => InodeTypes::EXT4_DE_BLKDEV,
+            VfsNodeType::File => InodeTypes::EXT4_DE_REG_FILE,
+            VfsNodeType::SymLink => InodeTypes::EXT4_DE_SYMLINK,
+            VfsNodeType::Socket => InodeTypes::EXT4_DE_SOCK,
+        };
+
+        let mut file = self.0.lock();
+        if file.check_inode_exist(fpath, types.clone()) {
+            Ok(())
+        } else {
+            if types == InodeTypes::EXT4_DE_DIR {
+                file.dir_mk(fpath)
+                    .map(|_v| ())
+                    .map_err(|e| e.try_into().unwrap())
+            } else {
+                file.file_open(fpath, O_WRONLY | O_CREAT | O_TRUNC)
+                    .expect("create file failed");
+                file.file_close()
+                    .map(|_v| ())
+                    .map_err(|e| e.try_into().unwrap())
+            }
+        }
+    }
+
+    fn remove(&self, path: &str) -> VfsResult {
+        info!("remove ext4fs: {}", path);
+        let fpath = self.path_deal_with(path);
+        let fpath = fpath.as_str();
+
+        assert!(!fpath.is_empty()); // already check at `root.rs`
+
+        let mut file = self.0.lock();
+        if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_DIR) {
+            // Recursive directory remove
+            file.dir_rm(fpath)
+                .map(|_v| ())
+                .map_err(|e| e.try_into().unwrap())
+        } else {
+            file.file_remove(fpath)
+                .map(|_v| ())
+                .map_err(|e| e.try_into().unwrap())
+        }
+    }
+
+    /// Get the parent directory of this directory.
+    /// Return `None` if the node is a file.
+    fn parent(&self) -> Option<VfsNodeRef> {
+        let file = self.0.lock();
+        if file.get_type() == InodeTypes::EXT4_DE_DIR {
+            let path = file.get_path();
+            let path = path.to_str().unwrap();
+            info!("Get the parent dir of {}", path);
+            let path = path.trim_end_matches('/').trim_end_matches(|c| c != '/');
+            if !path.is_empty() {
+                return Some(Arc::new(Self::new(path, InodeTypes::EXT4_DE_DIR)));
+            }
+        }
+        None
+    }
+
+    /// Read directory entries into `dirents`, starting from `start_idx`.
+    fn read_dir(&self, start_idx: usize, dirents: &mut [VfsDirEntry]) -> VfsResult<usize> {
+        let file = self.0.lock();
+        let (name, inode_type) = file.lwext4_dir_entries().unwrap();
+
+        let mut name_iter = name.iter().skip(start_idx);
+        let mut inode_type_iter = inode_type.iter().skip(start_idx);
+
+        for (i, out_entry) in dirents.iter_mut().enumerate() {
+            let iname = name_iter.next();
+            let itypes = inode_type_iter.next();
+
+            match itypes {
+                Some(t) => {
+                    let ty = if *t == InodeTypes::EXT4_DE_DIR {
+                        VfsNodeType::Dir
+                    } else if *t == InodeTypes::EXT4_DE_REG_FILE {
+                        VfsNodeType::File
+                    } else if *t == InodeTypes::EXT4_DE_SYMLINK {
+                        VfsNodeType::SymLink
+                    } else {
+                        error!("unknown file type: {:?}", itypes);
+                        unreachable!()
+                    };
+
+                    *out_entry =
+                        VfsDirEntry::new(core::str::from_utf8(iname.unwrap()).unwrap(), ty);
+                }
+                _ => return Ok(i),
+            }
+        }
+
+        Ok(dirents.len())
+    }
+
+    /// Lookup the node with given `path` in the directory.
+    /// Return the node if found.
+    fn lookup(self: Arc<Self>, path: &str) -> VfsResult<VfsNodeRef> {
+        debug!("lookup ext4fs: {:?}, {}", self.0.lock().get_path(), path);
+
+        let fpath = self.path_deal_with(path);
+        let fpath = fpath.as_str();
+        if fpath.is_empty() {
+            return Ok(self.clone());
+        }
+
+        let mut file = self.0.lock();
+        if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_DIR) {
+            debug!("lookup new DIR FileWrapper");
+            Ok(Arc::new(Self::new(fpath, InodeTypes::EXT4_DE_DIR)))
+        } else if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_REG_FILE) {
+            debug!("lookup new FILE FileWrapper");
+            Ok(Arc::new(Self::new(fpath, InodeTypes::EXT4_DE_REG_FILE)))
+        } else {
+            Err(VfsError::NotFound)
+        }
+    }
+
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
+        info!("To read_at {}, buf len={}", offset, buf.len());
+        let mut file = self.0.lock();
+        let path = file.get_path();
+        let path = path.to_str().unwrap();
+        file.file_open(path, O_RDONLY)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+
+        file.file_seek(offset as i64, SEEK_SET)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+        let r = file.file_read(buf);
+
+        let _ = file.file_close();
+        r.map_err(|e| e.try_into().unwrap())
+    }
+
+    fn write_at(&self, offset: u64, buf: &[u8]) -> VfsResult<usize> {
+        info!("To write_at {}, buf len={}", offset, buf.len());
+        let mut file = self.0.lock();
+        let path = file.get_path();
+        let path = path.to_str().unwrap();
+        file.file_open(path, O_RDWR)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+
+        file.file_seek(offset as i64, SEEK_SET)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+        let r = file.file_write(buf);
+
+        let _ = file.file_close();
+        r.map_err(|e| e.try_into().unwrap())
+    }
+
+    fn truncate(&self, size: u64) -> VfsResult {
+        info!("truncate file to size={}", size);
+        let mut file = self.0.lock();
+        let path = file.get_path();
+        let path = path.to_str().unwrap();
+        file.file_open(path, O_RDWR | O_CREAT | O_TRUNC)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+
+        let t = file.file_truncate(size);
+
+        let _ = file.file_close();
+        t.map(|_v| ()).map_err(|e| e.try_into().unwrap())
+    }
+
+    fn rename(&self, src_path: &str, dst_path: &str) -> VfsResult {
+        info!("rename from {} to {}", src_path, dst_path);
+        let mut file = self.0.lock();
+        file.file_rename(src_path, dst_path)
+            .map(|_v| ())
+            .map_err(|e| e.try_into().unwrap())
+    }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self as &dyn core::any::Any
+    }
+}
+
+impl Drop for FileWrapper {
+    fn drop(&mut self) {
+        let mut file = self.0.lock();
+        debug!("Drop struct FileWrapper {:?}", file.get_path());
+        file.file_close().expect("failed to close fd");
+        drop(file); // todo
+    }
+}
+
+impl KernelDevOp for Disk {
+    //type DevType = Box<Disk>;
+    type DevType = Disk;
+
+    fn read(dev: &mut Disk, mut buf: &mut [u8]) -> Result<usize, i32> {
+        debug!("READ block device buf={}", buf.len());
+        let mut read_len = 0;
+        while !buf.is_empty() {
+            match dev.read_one(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let tmp = buf;
+                    buf = &mut tmp[n..];
+                    read_len += n;
+                }
+                Err(_e) => return Err(-1),
+            }
+        }
+        debug!("READ rt len={}", read_len);
+        Ok(read_len)
+    }
+
+    fn write(dev: &mut Self::DevType, mut buf: &[u8]) -> Result<usize, i32> {
+        debug!("WRITE block device buf={}", buf.len());
+        let mut write_len = 0;
+        while !buf.is_empty() {
+            match dev.write_one(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    buf = &buf[n..];
+                    write_len += n;
+                }
+                Err(_e) => return Err(-1),
+            }
+        }
+        debug!("WRITE rt len={}", write_len);
+        Ok(write_len)
+    }
+
+    fn flush(_dev: &mut Self::DevType) -> Result<usize, i32> {
+        Ok(0)
+    }
+
+    fn seek(dev: &mut Disk, off: i64, whence: i32) -> Result<i64, i32> {
+        let size = dev.size();
+        debug!(
+            "SEEK block device size:{}, pos:{}, offset={}, whence={}",
+            size,
+            &dev.position(),
+            off,
+            whence
+        );
+        let new_pos = match whence as u32 {
+            SEEK_SET => Some(off),
+            SEEK_CUR => dev.position().checked_add_signed(off).map(|v| v as i64),
+            SEEK_END => size.checked_add_signed(off).map(|v| v as i64),
+            _ => {
+                error!("invalid seek() whence: {}", whence);
+                Some(off)
+            }
+        }
+        .ok_or(-1)?;
+
+        if new_pos as u64 > size {
+            warn!("Seek beyond the end of the block device");
+        }
+        dev.set_position(new_pos as u64);
+        Ok(new_pos)
+    }
+}

--- a/modules/axfs/src/fs/mod.rs
+++ b/modules/axfs/src/fs/mod.rs
@@ -1,6 +1,8 @@
 cfg_if::cfg_if! {
     if #[cfg(feature = "myfs")] {
         pub mod myfs;
+    } else if #[cfg(feature = "ext4fs")] {
+        pub mod ext4fs;
     } else if #[cfg(feature = "fatfs")] {
         pub mod fatfs;
     }

--- a/modules/axfs/src/root.rs
+++ b/modules/axfs/src/root.rs
@@ -150,6 +150,10 @@ pub(crate) fn init_rootfs(disk: crate::dev::Disk) {
     cfg_if::cfg_if! {
         if #[cfg(feature = "myfs")] { // override the default filesystem
             let main_fs = fs::myfs::new_myfs(disk);
+        } else if #[cfg(feature = "ext4fs")] {
+            static EXT4_FS: LazyInit<Arc<fs::ext4fs::Ext4FileSystem>> = LazyInit::new();
+            EXT4_FS.init_once(Arc::new(fs::ext4fs::Ext4FileSystem::new(disk)));
+            let main_fs = EXT4_FS.clone();
         } else if #[cfg(feature = "fatfs")] {
             static FAT_FS: LazyInit<Arc<fs::fatfs::FatFileSystem>> = LazyInit::new();
             FAT_FS.init_once(Arc::new(fs::fatfs::FatFileSystem::new(disk)));

--- a/scripts/make/features.mk
+++ b/scripts/make/features.mk
@@ -33,6 +33,10 @@ ifeq ($(APP_TYPE), c)
   endif
 endif
 
+ifeq ($(findstring ext4fs,$(FEATURES)),ext4fs)
+  override FEATURES += fp_simd
+endif
+
 override FEATURES := $(strip $(FEATURES))
 
 ax_feat :=

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -48,6 +48,8 @@ sched_cfs = ["axfeat/sched_cfs"]
 # File system
 fs = ["arceos_api/fs", "axfeat/fs"]
 myfs = ["arceos_api/myfs", "axfeat/myfs"]
+ext4fs = ["arceos_api/ext4fs", "axfeat/ext4fs"]
+fatfs = ["arceos_api/fatfs", "axfeat/fatfs"]
 
 # Networking
 net = ["arceos_api/net", "axfeat/net"]


### PR DESCRIPTION
向 ArceOS 添加了基于lwext4_rust的文件系统实现，使系统能够挂载并使用lwext4_rust文件系统作为根文件系统。

文件系统启用方式
在运行命令时需要通过 FEATURES 参数指定文件系统类型
`FEATURES=ext4fs`

创建测试磁盘镜像

# 创建空磁盘镜像

```
dd if=/dev/zero of=disk.img bs=1M count=32
```



# 格式化为 ext4 文件系统

```
mkfs.ext4 disk.img
```

系统运行命令

```
make A=examples/shell FEATURES=ext4fs BLK=y ACCEL=n ARCH=aarch64 run
```