### PR TITLE
support ext4 filesystem

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
         components: rust-src, clippy, rustfmt
         targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat, loongarch64-unknown-none
     - uses: Swatinem/rust-cache@v2
+    - uses: ./.github/workflows/actions/setup-musl
+      with:
+        arch: ${{ matrix.arch }}
     - name: Check rust version
       run: rustc --version --verbose
     - name: Check code format

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         toolchain: ${{ env.rust-toolchain }}
     - uses: Swatinem/rust-cache@v2
+    - uses: ./.github/workflows/actions/setup-musl
+      with:
+        arch: x86_64
     - name: Build docs
       continue-on-error: ${{ github.ref != env.default-branch && github.event_name != 'pull_request' }}
       run: make doc_check_missing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,12 +119,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
@@ -211,7 +211,7 @@ dependencies = [
  "axruntime",
  "axsync",
  "axtask",
- "bindgen",
+ "bindgen 0.69.5",
  "ctor_bare",
  "flatten_objects",
  "lazy_static",
@@ -461,6 +461,7 @@ dependencies = [
  "fatfs",
  "lazyinit",
  "log",
+ "lwext4_rust",
 ]
 
 [[package]]
@@ -558,7 +559,7 @@ dependencies = [
  "axerrno",
  "axfeat",
  "axio",
- "bindgen",
+ "bindgen 0.69.5",
 ]
 
 [[package]]
@@ -711,10 +712,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.101",
  "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1429,6 +1450,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lwext4_rust"
+version = "0.2.0"
+source = "git+https://github.com/Josen-B/lwext4_rust.git#5024eeebbe4859538e5802f8f719fafdc69c476c"
+dependencies = [
+ "bindgen 0.71.1",
+ "log",
+]
+
+[[package]]
 name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1542,15 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2611b99ab098a31bdc8be48b4f1a285ca0ced28bd5b4f23e45efa8c63b09efa5"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "page-table-generic"
@@ -1920,6 +1959,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"

--- a/api/arceos_api/Cargo.toml
+++ b/api/arceos_api/Cargo.toml
@@ -22,6 +22,8 @@ net = ["dep:axnet", "dep:axdriver", "axfeat/net"]
 display = ["dep:axdisplay", "dep:axdriver", "axfeat/display"]
 
 myfs = ["axfeat/myfs"]
+ext4fs = ["axfeat/ext4fs"]
+fatfs = ["axfeat/fatfs"]
 
 # Use dummy functions if the feature is not enabled
 dummy-if-not-enabled = []

--- a/api/axfeat/Cargo.toml
+++ b/api/axfeat/Cargo.toml
@@ -42,6 +42,8 @@ sched_cfs = ["axtask/sched_cfs", "irq"]
 # File system
 fs = ["alloc", "paging", "axdriver/virtio-blk", "dep:axfs", "axruntime/fs"] # TODO: try to remove "paging"
 myfs = ["axfs?/myfs"]
+ext4fs = ["axfs?/ext4fs"]
+fatfs = ["axfs?/fatfs"]
 
 # Networking
 net = ["alloc", "paging", "axdriver/virtio-net", "dep:axnet", "axruntime/net"]

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -14,6 +14,7 @@ devfs = ["dep:axfs_devfs"]
 ramfs = ["dep:axfs_ramfs"]
 procfs = ["dep:axfs_ramfs"]
 sysfs = ["dep:axfs_ramfs"]
+ext4fs = ["dep:lwext4_rust"]
 fatfs = ["dep:fatfs"]
 myfs = ["dep:crate_interface"]
 use-ramdisk = []
@@ -33,6 +34,7 @@ axfs_ramfs = { version = "0.1", optional = true }
 crate_interface = { version = "0.1", optional = true }
 axsync = { workspace = true }
 axdriver = { workspace = true, features = ["block"] }
+lwext4_rust = { git = "https://github.com/Josen-B/lwext4_rust.git", optional = true }
 axdriver_block = { git = "https://github.com/arceos-org/axdriver_crates.git", tag = "v0.1.2" }
 axns = { workspace = true }
 

--- a/modules/axfs/src/fs/ext4fs.rs
+++ b/modules/axfs/src/fs/ext4fs.rs
@@ -1,0 +1,408 @@
+use crate::alloc::string::String;
+use alloc::sync::Arc;
+use axerrno::AxError;
+use axfs_vfs::{VfsDirEntry, VfsError, VfsNodePerm, VfsResult};
+use axfs_vfs::{VfsNodeAttr, VfsNodeOps, VfsNodeRef, VfsNodeType, VfsOps};
+use axsync::Mutex;
+use lwext4_rust::bindings::{
+    O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY, SEEK_CUR, SEEK_END, SEEK_SET,
+};
+use lwext4_rust::{Ext4BlockWrapper, Ext4File, InodeTypes, KernelDevOp};
+
+use crate::dev::Disk;
+pub const BLOCK_SIZE: usize = 512;
+
+#[allow(dead_code)]
+pub struct Ext4FileSystem {
+    inner: Ext4BlockWrapper<Disk>,
+    root: VfsNodeRef,
+}
+
+unsafe impl Sync for Ext4FileSystem {}
+unsafe impl Send for Ext4FileSystem {}
+
+impl Ext4FileSystem {
+    #[cfg(feature = "use-ramdisk")]
+    pub fn new(mut disk: Disk) -> Self {
+        unimplemented!()
+    }
+
+    #[cfg(not(feature = "use-ramdisk"))]
+    pub fn new(disk: Disk) -> Self {
+        info!(
+            "Got Disk size:{}, position:{}",
+            disk.size(),
+            disk.position()
+        );
+        let inner =
+            Ext4BlockWrapper::<Disk>::new(disk).expect("failed to initialize EXT4 filesystem");
+        let root = Arc::new(FileWrapper::new("/", InodeTypes::EXT4_DE_DIR));
+        Self { inner, root }
+    }
+}
+
+/// The [`VfsOps`] trait provides operations on a filesystem.
+impl VfsOps for Ext4FileSystem {
+    // mount()
+
+    fn root_dir(&self) -> VfsNodeRef {
+        debug!("Get root_dir");
+        //let root_dir = unsafe { (*self.root.get()).as_ref().unwrap() };
+        Arc::clone(&self.root)
+    }
+}
+
+pub struct FileWrapper(Mutex<Ext4File>);
+
+unsafe impl Send for FileWrapper {}
+unsafe impl Sync for FileWrapper {}
+
+impl FileWrapper {
+    fn new(path: &str, types: InodeTypes) -> Self {
+        info!("FileWrapper new {:?} {}", types, path);
+        //file.file_read_test("/test/test.txt", &mut buf);
+
+        Self(Mutex::new(Ext4File::new(path, types)))
+    }
+
+    fn path_deal_with(&self, path: &str) -> String {
+        if path.starts_with('/') {
+            warn!("path_deal_with: {}", path);
+        }
+        let p = path.trim_matches('/');
+        if p.is_empty() || p == "." {
+            return String::new();
+        }
+
+        if let Some(rest) = p.strip_prefix("./") {
+            //if starts with "./"
+            return self.path_deal_with(rest);
+        }
+        let rest_p = p.replace("//", "/");
+        if p != rest_p {
+            return self.path_deal_with(&rest_p);
+        }
+
+        let file = self.0.lock();
+        let path = file.get_path();
+        let fpath = String::from(path.to_str().unwrap().trim_end_matches('/')) + "/" + p;
+        info!("dealt with full path: {}", fpath.as_str());
+        fpath
+    }
+}
+
+/// The [`VfsNodeOps`] trait provides operations on a file or a directory.
+impl VfsNodeOps for FileWrapper {
+    fn get_attr(&self) -> VfsResult<VfsNodeAttr> {
+        let mut file = self.0.lock();
+
+        let perm = file.file_mode_get().unwrap_or(0o755);
+        let perm = VfsNodePerm::from_bits_truncate((perm as u16) & 0o777);
+
+        let vtype = file.file_type_get();
+        let vtype = match vtype {
+            InodeTypes::EXT4_INODE_MODE_FIFO => VfsNodeType::Fifo,
+            InodeTypes::EXT4_INODE_MODE_CHARDEV => VfsNodeType::CharDevice,
+            InodeTypes::EXT4_INODE_MODE_DIRECTORY => VfsNodeType::Dir,
+            InodeTypes::EXT4_INODE_MODE_BLOCKDEV => VfsNodeType::BlockDevice,
+            InodeTypes::EXT4_INODE_MODE_FILE => VfsNodeType::File,
+            InodeTypes::EXT4_INODE_MODE_SOFTLINK => VfsNodeType::SymLink,
+            InodeTypes::EXT4_INODE_MODE_SOCKET => VfsNodeType::Socket,
+            _ => {
+                warn!("unknown file type: {:?}", vtype);
+                VfsNodeType::File
+            }
+        };
+
+        let size = if vtype == VfsNodeType::File {
+            let path = file.get_path();
+            let path = path.to_str().unwrap();
+            file.file_open(path, O_RDONLY)
+                .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+            let fsize = file.file_size();
+            let _ = file.file_close();
+            fsize
+        } else {
+            0
+        };
+        let blocks = (size + (BLOCK_SIZE as u64 - 1)) / BLOCK_SIZE as u64;
+
+        info!(
+            "get_attr of {:?} {:?}, size: {}, blocks: {}",
+            vtype,
+            file.get_path(),
+            size,
+            blocks
+        );
+
+        Ok(VfsNodeAttr::new(perm, vtype, size, blocks))
+    }
+
+    fn create(&self, path: &str, ty: VfsNodeType) -> VfsResult {
+        info!("create {:?} on Ext4fs: {}", ty, path);
+        let fpath = self.path_deal_with(path);
+        let fpath = fpath.as_str();
+        if fpath.is_empty() {
+            return Ok(());
+        }
+
+        let types = match ty {
+            VfsNodeType::Fifo => InodeTypes::EXT4_DE_FIFO,
+            VfsNodeType::CharDevice => InodeTypes::EXT4_DE_CHRDEV,
+            VfsNodeType::Dir => InodeTypes::EXT4_DE_DIR,
+            VfsNodeType::BlockDevice => InodeTypes::EXT4_DE_BLKDEV,
+            VfsNodeType::File => InodeTypes::EXT4_DE_REG_FILE,
+            VfsNodeType::SymLink => InodeTypes::EXT4_DE_SYMLINK,
+            VfsNodeType::Socket => InodeTypes::EXT4_DE_SOCK,
+        };
+
+        let mut file = self.0.lock();
+        if file.check_inode_exist(fpath, types.clone()) {
+            Ok(())
+        } else {
+            if types == InodeTypes::EXT4_DE_DIR {
+                file.dir_mk(fpath)
+                    .map(|_v| ())
+                    .map_err(|e| e.try_into().unwrap())
+            } else {
+                file.file_open(fpath, O_WRONLY | O_CREAT | O_TRUNC)
+                    .expect("create file failed");
+                file.file_close()
+                    .map(|_v| ())
+                    .map_err(|e| e.try_into().unwrap())
+            }
+        }
+    }
+
+    fn remove(&self, path: &str) -> VfsResult {
+        info!("remove ext4fs: {}", path);
+        let fpath = self.path_deal_with(path);
+        let fpath = fpath.as_str();
+
+        assert!(!fpath.is_empty()); // already check at `root.rs`
+
+        let mut file = self.0.lock();
+        if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_DIR) {
+            // Recursive directory remove
+            file.dir_rm(fpath)
+                .map(|_v| ())
+                .map_err(|e| e.try_into().unwrap())
+        } else {
+            file.file_remove(fpath)
+                .map(|_v| ())
+                .map_err(|e| e.try_into().unwrap())
+        }
+    }
+
+    /// Get the parent directory of this directory.
+    /// Return `None` if the node is a file.
+    fn parent(&self) -> Option<VfsNodeRef> {
+        let file = self.0.lock();
+        if file.get_type() == InodeTypes::EXT4_DE_DIR {
+            let path = file.get_path();
+            let path = path.to_str().unwrap();
+            info!("Get the parent dir of {}", path);
+            let path = path.trim_end_matches('/').trim_end_matches(|c| c != '/');
+            if !path.is_empty() {
+                return Some(Arc::new(Self::new(path, InodeTypes::EXT4_DE_DIR)));
+            }
+        }
+        None
+    }
+
+    /// Read directory entries into `dirents`, starting from `start_idx`.
+    fn read_dir(&self, start_idx: usize, dirents: &mut [VfsDirEntry]) -> VfsResult<usize> {
+        let file = self.0.lock();
+        let (name, inode_type) = file.lwext4_dir_entries().unwrap();
+
+        let mut name_iter = name.iter().skip(start_idx);
+        let mut inode_type_iter = inode_type.iter().skip(start_idx);
+
+        for (i, out_entry) in dirents.iter_mut().enumerate() {
+            let iname = name_iter.next();
+            let itypes = inode_type_iter.next();
+
+            match itypes {
+                Some(t) => {
+                    let ty = if *t == InodeTypes::EXT4_DE_DIR {
+                        VfsNodeType::Dir
+                    } else if *t == InodeTypes::EXT4_DE_REG_FILE {
+                        VfsNodeType::File
+                    } else if *t == InodeTypes::EXT4_DE_SYMLINK {
+                        VfsNodeType::SymLink
+                    } else {
+                        error!("unknown file type: {:?}", itypes);
+                        unreachable!()
+                    };
+
+                    *out_entry =
+                        VfsDirEntry::new(core::str::from_utf8(iname.unwrap()).unwrap(), ty);
+                }
+                _ => return Ok(i),
+            }
+        }
+
+        Ok(dirents.len())
+    }
+
+    /// Lookup the node with given `path` in the directory.
+    /// Return the node if found.
+    fn lookup(self: Arc<Self>, path: &str) -> VfsResult<VfsNodeRef> {
+        debug!("lookup ext4fs: {:?}, {}", self.0.lock().get_path(), path);
+
+        let fpath = self.path_deal_with(path);
+        let fpath = fpath.as_str();
+        if fpath.is_empty() {
+            return Ok(self.clone());
+        }
+
+        let mut file = self.0.lock();
+        if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_DIR) {
+            debug!("lookup new DIR FileWrapper");
+            Ok(Arc::new(Self::new(fpath, InodeTypes::EXT4_DE_DIR)))
+        } else if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_REG_FILE) {
+            debug!("lookup new FILE FileWrapper");
+            Ok(Arc::new(Self::new(fpath, InodeTypes::EXT4_DE_REG_FILE)))
+        } else {
+            Err(VfsError::NotFound)
+        }
+    }
+
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
+        info!("To read_at {}, buf len={}", offset, buf.len());
+        let mut file = self.0.lock();
+        let path = file.get_path();
+        let path = path.to_str().unwrap();
+        file.file_open(path, O_RDONLY)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+
+        file.file_seek(offset as i64, SEEK_SET)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+        let r = file.file_read(buf);
+
+        let _ = file.file_close();
+        r.map_err(|e| e.try_into().unwrap())
+    }
+
+    fn write_at(&self, offset: u64, buf: &[u8]) -> VfsResult<usize> {
+        info!("To write_at {}, buf len={}", offset, buf.len());
+        let mut file = self.0.lock();
+        let path = file.get_path();
+        let path = path.to_str().unwrap();
+        file.file_open(path, O_RDWR)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+
+        file.file_seek(offset as i64, SEEK_SET)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+        let r = file.file_write(buf);
+
+        let _ = file.file_close();
+        r.map_err(|e| e.try_into().unwrap())
+    }
+
+    fn truncate(&self, size: u64) -> VfsResult {
+        info!("truncate file to size={}", size);
+        let mut file = self.0.lock();
+        let path = file.get_path();
+        let path = path.to_str().unwrap();
+        file.file_open(path, O_RDWR | O_CREAT | O_TRUNC)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+
+        let t = file.file_truncate(size);
+
+        let _ = file.file_close();
+        t.map(|_v| ()).map_err(|e| e.try_into().unwrap())
+    }
+
+    fn rename(&self, src_path: &str, dst_path: &str) -> VfsResult {
+        info!("rename from {} to {}", src_path, dst_path);
+        let mut file = self.0.lock();
+        file.file_rename(src_path, dst_path)
+            .map(|_v| ())
+            .map_err(|e| e.try_into().unwrap())
+    }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self as &dyn core::any::Any
+    }
+}
+
+impl Drop for FileWrapper {
+    fn drop(&mut self) {
+        let mut file = self.0.lock();
+        debug!("Drop struct FileWrapper {:?}", file.get_path());
+        file.file_close().expect("failed to close fd");
+        drop(file); // todo
+    }
+}
+
+impl KernelDevOp for Disk {
+    //type DevType = Box<Disk>;
+    type DevType = Disk;
+
+    fn read(dev: &mut Disk, mut buf: &mut [u8]) -> Result<usize, i32> {
+        debug!("READ block device buf={}", buf.len());
+        let mut read_len = 0;
+        while !buf.is_empty() {
+            match dev.read_one(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let tmp = buf;
+                    buf = &mut tmp[n..];
+                    read_len += n;
+                }
+                Err(_e) => return Err(-1),
+            }
+        }
+        debug!("READ rt len={}", read_len);
+        Ok(read_len)
+    }
+
+    fn write(dev: &mut Self::DevType, mut buf: &[u8]) -> Result<usize, i32> {
+        debug!("WRITE block device buf={}", buf.len());
+        let mut write_len = 0;
+        while !buf.is_empty() {
+            match dev.write_one(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    buf = &buf[n..];
+                    write_len += n;
+                }
+                Err(_e) => return Err(-1),
+            }
+        }
+        debug!("WRITE rt len={}", write_len);
+        Ok(write_len)
+    }
+
+    fn flush(_dev: &mut Self::DevType) -> Result<usize, i32> {
+        Ok(0)
+    }
+
+    fn seek(dev: &mut Disk, off: i64, whence: i32) -> Result<i64, i32> {
+        let size = dev.size();
+        debug!(
+            "SEEK block device size:{}, pos:{}, offset={}, whence={}",
+            size,
+            &dev.position(),
+            off,
+            whence
+        );
+        let new_pos = match whence as u32 {
+            SEEK_SET => Some(off),
+            SEEK_CUR => dev.position().checked_add_signed(off).map(|v| v as i64),
+            SEEK_END => size.checked_add_signed(off).map(|v| v as i64),
+            _ => {
+                error!("invalid seek() whence: {}", whence);
+                Some(off)
+            }
+        }
+        .ok_or(-1)?;
+
+        if new_pos as u64 > size {
+            warn!("Seek beyond the end of the block device");
+        }
+        dev.set_position(new_pos as u64);
+        Ok(new_pos)
+    }
+}

--- a/modules/axfs/src/fs/mod.rs
+++ b/modules/axfs/src/fs/mod.rs
@@ -1,6 +1,8 @@
 cfg_if::cfg_if! {
     if #[cfg(feature = "myfs")] {
         pub mod myfs;
+    } else if #[cfg(feature = "ext4fs")] {
+        pub mod ext4fs;
     } else if #[cfg(feature = "fatfs")] {
         pub mod fatfs;
     }

--- a/modules/axfs/src/root.rs
+++ b/modules/axfs/src/root.rs
@@ -150,6 +150,10 @@ pub(crate) fn init_rootfs(disk: crate::dev::Disk) {
     cfg_if::cfg_if! {
         if #[cfg(feature = "myfs")] { // override the default filesystem
             let main_fs = fs::myfs::new_myfs(disk);
+         } else if #[cfg(feature = "ext4fs")] {
+            static EXT4_FS: LazyInit<Arc<fs::ext4fs::Ext4FileSystem>> = LazyInit::new();
+            EXT4_FS.init_once(Arc::new(fs::ext4fs::Ext4FileSystem::new(disk)));
+            let main_fs = EXT4_FS.clone();
         } else if #[cfg(feature = "fatfs")] {
             static FAT_FS: LazyInit<Arc<fs::fatfs::FatFileSystem>> = LazyInit::new();
             FAT_FS.init_once(Arc::new(fs::fatfs::FatFileSystem::new(disk)));

--- a/scripts/make/features.mk
+++ b/scripts/make/features.mk
@@ -33,6 +33,10 @@ ifeq ($(APP_TYPE), c)
   endif
 endif
 
+ifeq ($(findstring ext4fs,$(FEATURES)),ext4fs)
+  override FEATURES += fp_simd
+endif
+
 override FEATURES := $(strip $(FEATURES))
 
 ax_feat :=

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -49,6 +49,8 @@ sched_cfs = ["axfeat/sched_cfs"]
 # File system
 fs = ["arceos_api/fs", "axfeat/fs"]
 myfs = ["arceos_api/myfs", "axfeat/myfs"]
+ext4fs = ["arceos_api/ext4fs", "axfeat/ext4fs"]
+fatfs = ["arceos_api/fatfs", "axfeat/fatfs"]
 
 # Networking
 net = ["arceos_api/net", "axfeat/net"]


### PR DESCRIPTION
向 ArceOS 添加了基于lwext4_rust的文件系统实现，使系统能够挂载并使用lwext4_rust文件系统作为根文件系统。

文件系统启用方式
在运行命令时需要通过 FEATURES 参数指定文件系统类型
`FEATURES=ext4fs`

创建测试磁盘镜像

# 创建空磁盘镜像

```
dd if=/dev/zero of=disk.img bs=1M count=32
```



# 格式化为 ext4 文件系统

```
mkfs.ext4 disk.img
```

系统运行命令

```
make A=examples/shell FEATURES=ext4fs BLK=y ACCEL=n ARCH=aarch64 run
```