### PR TITLE
fix(aarch64-rk3588j): fix memory mapping and kernel loading address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ ifeq ($(PLAT_NAME), aarch64-raspi4)
   include scripts/make/raspi4.mk
 else ifeq ($(PLAT_NAME), aarch64-bsta1000b)
   include scripts/make/bsta1000b-fada.mk
-else ifeq ($(PLATFORM_NAME), aarch64-rk3588j)
+else ifeq ($(PLAT_NAME), aarch64-rk3588j)
   include scripts/make/rk3588.mk
 endif
 

--- a/configs/platforms/aarch64-rk3588j.toml
+++ b/configs/platforms/aarch64-rk3588j.toml
@@ -17,7 +17,7 @@ phys-memory-size = 0x800_0000       # uint
 # Base physical address of the kernel image.
 kernel-base-paddr = 0x48_0000       # uint
 # Base virtual address of the kernel image.
-kernel-base-vaddr = "0x0000_0000_0048_0000"     # uint
+kernel-base-vaddr = "0xffff_0000_0048_0000"     # uint
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_0000_0000_0000"      # uint

--- a/modules/axhal/Cargo.toml
+++ b/modules/axhal/Cargo.toml
@@ -57,7 +57,7 @@ riscv_goldfish = { version = "0.1", optional = true }
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64-cpu = "10.0"
 tock-registers = "0.9"
-arm-gic-driver = { git = "https://github.com/rcore-os/arm-gic-driver", rev = "ad1fddc194f1cf5b7602e7f35a7136f823465cb0" }
+arm-gic-driver = "0.14"
 crate_interface = { version = "0.1.3", optional = true }
 arm_pl011 = "0.1"
 arm_pl031 = { version = "0.2", optional = true }

--- a/modules/axhal/src/platform/aarch64_bsta1000b/mem.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/mem.rs
@@ -4,8 +4,8 @@ use page_table_entry::{GenericPTE, MappingFlags, aarch64::A64PTE};
 /// Returns (a1000b only) memory regions.
 pub(crate) fn default_a1000b_regions() -> impl Iterator<Item = MemRegion> {
     [MemRegion {
-        paddr: pa!(0x1_b000_0000),
-        size: 0x40000000,
+        paddr: pa!(0x8000_0000),
+        size: 0x70000000,
         flags: MemRegionFlags::RESERVED | MemRegionFlags::READ | MemRegionFlags::WRITE,
         name: "reserved memory",
     }]

--- a/modules/axhal/src/platform/aarch64_bsta1000b/mem.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/mem.rs
@@ -4,8 +4,8 @@ use page_table_entry::{GenericPTE, MappingFlags, aarch64::A64PTE};
 /// Returns (a1000b only) memory regions.
 pub(crate) fn default_a1000b_regions() -> impl Iterator<Item = MemRegion> {
     [MemRegion {
-        paddr: pa!(0x80000000),
-        size: 0x70000000,
+        paddr: pa!(0x1_b000_0000),
+        size: 0x40000000,
         flags: MemRegionFlags::RESERVED | MemRegionFlags::READ | MemRegionFlags::WRITE,
         name: "reserved memory",
     }]

--- a/modules/axhal/src/platform/aarch64_common/gicv3.rs
+++ b/modules/axhal/src/platform/aarch64_common/gicv3.rs
@@ -98,7 +98,6 @@ pub(crate) fn init_primary() {
     let mut gicd = arm_gic_driver::v3::Gic::new(
         NonNull::new(phys_to_virt(GICD_BASE).as_mut_ptr()).unwrap(),
         NonNull::new(phys_to_virt(GICR_BASE).as_mut_ptr()).unwrap(),
-        arm_gic_driver::v3::Security::OneNS,
     );
 
     debug!("Initializing GICD at {:#x}", GICD_BASE);

--- a/scripts/make/rk3588.mk
+++ b/scripts/make/rk3588.mk
@@ -9,5 +9,5 @@ ifeq ("$(wildcard $(RK3588_MKIMG_FILE))","")
 endif
 
 kernel: check-download build
-	$(RK3588_MKIMG_FILE) --dtb rk3588-firefly-itx-3588j.dtb --img $(OUT_BIN)
+	$(RK3588_MKIMG_FILE) --dtb rk3588-firefly-itx-3588j.dtb --img $(abspath $(OUT_BIN))
 	@echo 'Built the FIT-uImage boot.img'


### PR DESCRIPTION
- Update kernel virtual address mapping for aarch64-rk3588j platform
- Adjust the starting address and size of physical memory area
- Correct command parameters in rk3588.mk