### PR TITLE
feat: 添加动态驱动支持，更新依赖项并实现 GICv2 和 GICv3 驱动

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,15 +202,16 @@ dependencies = [
 
 [[package]]
 name = "arm-gic-driver"
-version = "0.15.5"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234fbc75ee659ae0fa44cdbe9a61f84cc4a107b024efd872e7ad56ad82f9ab08"
+checksum = "f251a1a74133f802b55eaf5e340107b0024457aa9b2ac3c72074501bfa8509a5"
 dependencies = [
  "aarch64-cpu 10.0.0",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "enum_dispatch",
  "log",
  "paste",
+ "rdif-intc",
  "tock-registers 0.9.0",
 ]
 
@@ -230,6 +231,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13696b1c2b59992f4223e0ae5bb173c81c63039367ca90eee845346ad2a13421"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -341,6 +359,7 @@ dependencies = [
 name = "axdriver"
 version = "0.2.0"
 dependencies = [
+ "arm-gic-driver",
  "axalloc",
  "axconfig",
  "axdma",
@@ -350,10 +369,14 @@ dependencies = [
  "axdriver_net",
  "axdriver_pci",
  "axdriver_virtio",
+ "axerrno",
  "axhal",
  "cfg-if",
  "crate_interface",
+ "lazyinit",
  "log",
+ "memory_addr",
+ "rdrive",
 ]
 
 [[package]]
@@ -489,7 +512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcba2006898d7879d456a9c34b9c9460cb536f5bf69d1d5d7d0e0f19f073368d"
 dependencies = [
  "axerrno",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "log",
 ]
 
@@ -611,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4de04c54b63bf2ca1ff202733d2516da49d7779649cdb2f9c4ecf22909e6810"
 dependencies = [
  "axplat-macros",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "const-str",
  "crate_interface",
  "handler_table",
@@ -751,7 +774,7 @@ dependencies = [
  "axconfig-macros",
  "axcpu",
  "axplat",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "heapless 0.9.1",
  "int_ratio",
  "kspin",
@@ -775,6 +798,7 @@ dependencies = [
  "axconfig",
  "axdisplay",
  "axdriver",
+ "axerrno",
  "axfs",
  "axhal",
  "axipi",
@@ -865,7 +889,7 @@ version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -887,9 +911,9 @@ checksum = "2b645c5c09a7d4035949cfce1a915785aaad6f17800c35fda8a8c311c491f284"
 
 [[package]]
 name = "bit_field"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -899,9 +923,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "bitmap-allocator"
@@ -942,14 +966,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9b24894fa5f73bbf9c72196e7f495a1f81d6218a548280a09ada4a937157692"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.33"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "shlex",
 ]
@@ -996,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1006,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1195,9 +1219,15 @@ name = "fatfs"
 version = "0.4.0"
 source = "git+https://github.com/rafalh/rust-fatfs?rev=4eccb50#4eccb50d011146fbed20e133d33b22f3c27292e7"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "log",
 ]
+
+[[package]]
+name = "fdt-parser"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ca123a5721e4a28ef60d6e1600cd0a33a9ab376c4b88de04c99bce757e458b"
 
 [[package]]
 name = "flatten_objects"
@@ -1206,6 +1236,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7719d63de27ac93e7cd2c8e0c03083f8b0ff7f842fdb6280b8cdcac21b4baf"
 dependencies = [
  "bitmaps",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1331,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1482,7 +1573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c9f0d275c70310e2a9d2fc23250c5ac826a73fa828a5f256401f85c5c554283"
 dependencies = [
  "bit_field",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -1571,7 +1662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba811ef8ca8fb33d776e128624cb4fe25c9804cab96f83b822d4322431e6dd5a"
 dependencies = [
  "aarch64-cpu 10.0.0",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "memory_addr",
  "x86_64",
 ]
@@ -1619,6 +1710,18 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -1729,14 +1832,128 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
+]
+
+[[package]]
+name = "rdif-base"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6953f438bbbdf58e55513c31e70fa0f85daba2927e8a59130a04608141bb552"
+dependencies = [
+ "as-any",
+ "async-trait",
+ "rdif-def",
+ "thiserror",
+]
+
+[[package]]
+name = "rdif-block"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7b8e19dc3cb6cd7241085a9560a91d4346edbc525bcbfc3c86e5eeb11559c19"
+dependencies = [
+ "cfg-if",
+ "rdif-base",
+]
+
+[[package]]
+name = "rdif-clk"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee94bb098e921346fffa3bb8d18e80fbb903c8ad2cb0a103ee9a65ae1a7d77fa"
+dependencies = [
+ "rdif-base",
+]
+
+[[package]]
+name = "rdif-def"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c238eb44d86fabc99028adc973f896ce2202aeb6184cc8b89863f2d157d7ca06"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "rdif-intc"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29b44e4bbb180ed0031e22a54d802f77226faf7064e52fcc8cf25c2376cb2ff"
+dependencies = [
+ "cfg-if",
+ "rdif-base",
+ "thiserror",
+]
+
+[[package]]
+name = "rdif-power"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37eb02828548e3d1bb13d2a5d892219dfa295c3c0c00a1a647a68f947e5d070a"
+dependencies = [
+ "rdif-base",
+]
+
+[[package]]
+name = "rdif-serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3381d491f588cfb20dfa661dc374411a2cb91c751b2e18516e0d2edca6a58e"
+dependencies = [
+ "futures",
+ "rdif-base",
+ "spin_on",
+ "thiserror",
+]
+
+[[package]]
+name = "rdif-systick"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdd145eab68c38f23dfcc8b3b1ed20c48bbb1a4278dd9c7bf64e9219cc61158"
+dependencies = [
+ "rdif-base",
+]
+
+[[package]]
+name = "rdrive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3af299bb0304ce80c3d53b9c6458896d7d6a923cb67cd70ec8ef62994762f1"
+dependencies = [
+ "enum_dispatch",
+ "fdt-parser",
+ "log",
+ "paste",
+ "rdif-base",
+ "rdif-block",
+ "rdif-clk",
+ "rdif-intc",
+ "rdif-power",
+ "rdif-serial",
+ "rdif-systick",
+ "rdrive-macros",
+ "spin 0.10.0",
+ "thiserror",
+]
+
+[[package]]
+name = "rdrive-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab3105c9af32e901a2adc7d920b39ff8b6ee0f6f0b7dfdeaf18f306ec12606f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1746,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1757,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "riscv"
@@ -1918,6 +2135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin_on"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076e103ed41b9864aa838287efe5f4e3a7a0362dd00671ae62a212e5e4612da2"
+dependencies = [
+ "pin-utils",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,7 +2264,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d293f51425981fdb1b766beae254dbb711a17e8c4b549dc69b9b7ee0d478d5"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "rustversion",
  "x86",
 ]
@@ -2067,7 +2293,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa40e09453618c7a927c08c5a990497a2954da7c2aaa6c65e0d4f0fc975f6114"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "log",
  "zerocopy 0.7.35",
 ]
@@ -2292,9 +2518,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -2305,7 +2531,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -2339,7 +2565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
 dependencies = [
  "bit_field",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "rustversion",
  "volatile 0.4.6",
 ]

--- a/api/axfeat/Cargo.toml
+++ b/api/axfeat/Cargo.toml
@@ -57,6 +57,7 @@ display = ["alloc", "paging", "axdriver/virtio-gpu", "dep:axdisplay", "axruntime
 rtc = ["axhal/rtc", "axruntime/rtc"]
 
 # Device drivers
+driver-dyn = ["axruntime/driver-dyn","axdriver?/dyn"]
 bus-mmio = ["axdriver?/bus-mmio"]
 bus-pci = ["axdriver?/bus-pci"]
 driver-ramdisk = ["axdriver?/ramdisk", "axfs?/use-ramdisk"]

--- a/modules/axdriver/Cargo.toml
+++ b/modules/axdriver/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/arceos-org/arceos/tree/main/modules/axdriver"
 documentation = "https://arceos-org.github.io/arceos/axdriver/index.html"
 
 [features]
-dyn = []
+dyn = ["dep:rdrive", "dep:arm-gic-driver", "arm-gic-driver?/rdif"]
 bus-mmio = []
 bus-pci = ["dep:axdriver_pci", "dep:axhal", "dep:axconfig"]
 net = ["axdriver_net"]
@@ -46,3 +46,10 @@ axalloc = { workspace = true, optional = true }
 axhal = { workspace = true, optional = true }
 axconfig = { workspace = true, optional = true }
 axdma = { workspace = true, optional = true }
+rdrive = { version = "0.16", optional = true }
+axerrno = "0.1"
+lazyinit = "0.2"
+memory_addr = "0.4"
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+arm-gic-driver = { version = "0.15", optional = true }

--- a/modules/axdriver/src/dyn_drivers/blk/mod.rs
+++ b/modules/axdriver/src/dyn_drivers/blk/mod.rs
@@ -1,0 +1,87 @@
+use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
+use axdriver_block::BlockDriverOps;
+use rdrive::{Device, driver::block::io};
+
+#[cfg(feature = "virtio-blk")]
+mod virtio;
+
+pub struct Block(Device<rdrive::driver::Block>);
+
+impl BaseDriverOps for Block {
+    fn device_type(&self) -> DeviceType {
+        DeviceType::Block
+    }
+    fn device_name(&self) -> &str {
+        self.0.descriptor().name
+    }
+}
+
+impl BlockDriverOps for Block {
+    fn num_blocks(&self) -> u64 {
+        self.0.lock().unwrap().num_blocks() as _
+    }
+    fn block_size(&self) -> usize {
+        self.0.lock().unwrap().block_size()
+    }
+    fn flush(&mut self) -> DevResult {
+        self.0
+            .lock()
+            .unwrap()
+            .flush()
+            .map_err(maping_io_err_to_dev_err)
+    }
+
+    fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> DevResult {
+        self.0
+            .lock()
+            .unwrap()
+            .read_block(block_id as _, buf)
+            .map_err(maping_io_err_to_dev_err)
+    }
+
+    fn write_block(&mut self, block_id: u64, buf: &[u8]) -> DevResult {
+        self.0
+            .lock()
+            .unwrap()
+            .write_block(block_id as _, buf)
+            .map_err(maping_io_err_to_dev_err)
+    }
+}
+
+impl From<Device<rdrive::driver::Block>> for Block {
+    fn from(base: Device<rdrive::driver::Block>) -> Self {
+        Self(base)
+    }
+}
+
+fn maping_io_err_to_dev_err(err: io::Error) -> DevError {
+    match err.kind {
+        io::ErrorKind::Other(_error) => DevError::Io,
+        io::ErrorKind::NotAvailable => DevError::BadState,
+        io::ErrorKind::BrokenPipe => DevError::BadState,
+        io::ErrorKind::InvalidParameter { name: _ } => DevError::InvalidParam,
+        io::ErrorKind::InvalidData => DevError::InvalidParam,
+        io::ErrorKind::TimedOut => DevError::Io,
+        io::ErrorKind::Interrupted => DevError::Again,
+        io::ErrorKind::Unsupported => DevError::Unsupported,
+        io::ErrorKind::OutOfMemory => DevError::NoMemory,
+        io::ErrorKind::WriteZero => DevError::InvalidParam,
+    }
+}
+
+fn maping_dev_err_to_io_err(err: DevError) -> io::Error {
+    let kind = match err {
+        DevError::Again => io::ErrorKind::Interrupted,
+        DevError::AlreadyExists => io::ErrorKind::Other("Already exists".into()),
+        DevError::BadState => io::ErrorKind::BrokenPipe,
+        DevError::InvalidParam => io::ErrorKind::InvalidData,
+        DevError::Io => io::ErrorKind::Other("I/O error".into()),
+        DevError::NoMemory => io::ErrorKind::OutOfMemory,
+        DevError::ResourceBusy => io::ErrorKind::Other("Resource busy".into()),
+        DevError::Unsupported => io::ErrorKind::Unsupported,
+    };
+    io::Error {
+        kind,
+        success_pos: 0,
+    }
+}

--- a/modules/axdriver/src/dyn_drivers/blk/virtio.rs
+++ b/modules/axdriver/src/dyn_drivers/blk/virtio.rs
@@ -1,0 +1,99 @@
+extern crate alloc;
+
+use alloc::format;
+use axdriver_base::DeviceType;
+use axdriver_block::BlockDriverOps;
+use axdriver_virtio::MmioTransport;
+use axhal::mem::PhysAddr;
+use rdrive::{
+    DriverGeneric, PlatformDevice, driver::block::*, module_driver, probe::OnProbeError,
+    register::FdtInfo,
+};
+
+use crate::dyn_drivers::blk::maping_dev_err_to_io_err;
+use crate::dyn_drivers::iomap;
+use crate::virtio::VirtIoHalImpl;
+
+type Device<T> = axdriver_virtio::VirtIoBlkDev<VirtIoHalImpl, T>;
+
+module_driver!(
+    name: "Virtio Block",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["virtio,mmio"],
+            on_probe: probe
+        }
+    ],
+);
+
+fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError> {
+    let base_reg = info
+        .node
+        .reg()
+        .and_then(|mut regs| regs.next())
+        .ok_or(OnProbeError::other(alloc::format!(
+            "[{}] has no reg",
+            info.node.name()
+        )))?;
+
+    let mmio_size = base_reg.size.unwrap_or(0x1000);
+    let mmio_base = PhysAddr::from_usize(base_reg.address as usize);
+
+    let mmio_base = iomap(mmio_base, mmio_size)?.as_ptr();
+
+    let (ty, transport) =
+        axdriver_virtio::probe_mmio_device(mmio_base, mmio_size).ok_or(OnProbeError::NotMatch)?;
+
+    if ty != DeviceType::Block {
+        return Err(OnProbeError::NotMatch);
+    }
+
+    let dev = Device::try_new(transport).map_err(|e| {
+        OnProbeError::other(format!(
+            "failed to initialize Virtio Block device at [PA:{mmio_base:?},): {e:?}"
+        ))
+    })?;
+
+    let dev = BlockDivce(dev);
+    plat_dev.register_block(dev);
+    debug!("virtio block device registered successfully");
+    Ok(())
+}
+
+struct BlockDivce(Device<MmioTransport>);
+
+impl DriverGeneric for BlockDivce {
+    fn open(&mut self) -> Result<(), rdrive::KError> {
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<(), rdrive::KError> {
+        Ok(())
+    }
+}
+
+impl rdrive::driver::block::Interface for BlockDivce {
+    fn num_blocks(&self) -> usize {
+        self.0.num_blocks() as _
+    }
+
+    fn block_size(&self) -> usize {
+        self.0.block_size()
+    }
+
+    fn read_block(&mut self, block_id: usize, buf: &mut [u8]) -> Result<(), io::Error> {
+        self.0
+            .read_block(block_id as u64, buf)
+            .map_err(maping_dev_err_to_io_err)
+    }
+    fn write_block(&mut self, block_id: usize, buf: &[u8]) -> Result<(), io::Error> {
+        self.0
+            .write_block(block_id as u64, buf)
+            .map_err(maping_dev_err_to_io_err)
+    }
+    fn flush(&mut self) -> Result<(), io::Error> {
+        self.0.flush().map_err(maping_dev_err_to_io_err)
+    }
+}

--- a/modules/axdriver/src/dyn_drivers/intc/gicv2.rs
+++ b/modules/axdriver/src/dyn_drivers/intc/gicv2.rs
@@ -1,0 +1,61 @@
+extern crate alloc;
+
+use alloc::format;
+use arm_gic_driver::v2::{Gic, HyperAddress};
+use rdrive::{PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo};
+
+use crate::dyn_drivers::iomap;
+
+module_driver!(
+    name: "GICv2",
+    level: ProbeLevel::PreKernel,
+    priority: ProbePriority::INTC,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["arm,cortex-a15-gic", "arm,gic-400"],
+            on_probe: probe_gic
+        },
+    ] ,
+);
+
+fn probe_gic(info: FdtInfo<'_>, dev: PlatformDevice) -> Result<(), OnProbeError> {
+    let mut reg = info.node.reg().ok_or(OnProbeError::other(format!(
+        "[{}] has no reg",
+        info.node.name()
+    )))?;
+
+    let gicd_reg = reg.next().unwrap();
+    let gicc_reg = reg.next().unwrap();
+
+    let gicd = iomap(
+        (gicd_reg.address as usize).into(),
+        gicd_reg.size.unwrap_or(0x1000),
+    )?;
+    let gicc = iomap(
+        (gicc_reg.address as usize).into(),
+        gicc_reg.size.unwrap_or(0x1000),
+    )?;
+
+    let mut hyper = None;
+
+    if let Some(gich_reg) = reg.next() {
+        if let Some(gicv_reg) = reg.next() {
+            let gich = iomap(
+                (gich_reg.address as usize).into(),
+                gich_reg.size.unwrap_or(0x1000),
+            )?;
+            let gicv = iomap(
+                (gicv_reg.address as usize).into(),
+                gicv_reg.size.unwrap_or(0x1000),
+            )?;
+
+            hyper = Some(HyperAddress::new(gich.into(), gicv.into()))
+        }
+    }
+
+    let gic = unsafe { Gic::new(gicd.into(), gicc.into(), hyper) };
+
+    dev.register_intc(gic);
+
+    Ok(())
+}

--- a/modules/axdriver/src/dyn_drivers/intc/gicv3.rs
+++ b/modules/axdriver/src/dyn_drivers/intc/gicv3.rs
@@ -1,0 +1,44 @@
+extern crate alloc;
+
+use alloc::format;
+use arm_gic_driver::v3::Gic;
+use rdrive::{PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo};
+
+use crate::dyn_drivers::iomap;
+
+module_driver!(
+    name: "GICv3",
+    level: ProbeLevel::PreKernel,
+    priority: ProbePriority::INTC,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["arm,gic-v3"],
+            on_probe: probe_gic
+        }
+    ],
+);
+
+fn probe_gic(info: FdtInfo<'_>, dev: PlatformDevice) -> Result<(), OnProbeError> {
+    let mut reg = info.node.reg().ok_or(OnProbeError::other(format!(
+        "[{}] has no reg",
+        info.node.name()
+    )))?;
+
+    let gicd_reg = reg.next().unwrap();
+    let gicr_reg = reg.next().unwrap();
+
+    let gicd = iomap(
+        (gicd_reg.address as usize).into(),
+        gicd_reg.size.unwrap_or(0x1000),
+    )?;
+    let gicr = iomap(
+        (gicr_reg.address as usize).into(),
+        gicr_reg.size.unwrap_or(0x1000),
+    )?;
+
+    let gic = unsafe { Gic::new(gicd.into(), gicr.into()) };
+
+    dev.register_intc(gic);
+
+    Ok(())
+}

--- a/modules/axdriver/src/dyn_drivers/intc/mod.rs
+++ b/modules/axdriver/src/dyn_drivers/intc/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(target_arch = "aarch64")]
+mod gicv2;
+#[cfg(target_arch = "aarch64")]
+mod gicv3;

--- a/modules/axdriver/src/dyn_drivers/mod.rs
+++ b/modules/axdriver/src/dyn_drivers/mod.rs
@@ -1,0 +1,78 @@
+use core::{error::Error, ops::Deref, ptr::NonNull};
+
+use alloc::{boxed::Box, format, string::ToString};
+use axerrno::{AxError, AxResult};
+use axhal::mem::{PhysAddr, VirtAddr, phys_to_virt};
+use lazyinit::LazyInit;
+use memory_addr::MemoryAddr;
+use rdrive::register::{DriverRegister, DriverRegisterSlice};
+
+mod intc;
+
+#[cfg(feature = "block")]
+pub mod blk;
+
+/// A function type that maps a physical address to a virtual address. map flags should be read/write/device.
+pub type IoMapFunc = fn(PhysAddr, usize) -> AxResult<VirtAddr>;
+
+static IO_MAP_FUNC: LazyInit<IoMapFunc> = LazyInit::new();
+
+/// Sets up the device driver subsystem.
+pub fn setup(dtb: usize, io_map_func: IoMapFunc) {
+    IO_MAP_FUNC.init_once(io_map_func);
+    if dtb == 0 {
+        warn!("Device tree base address is 0, skipping device driver setup.");
+        return;
+    }
+
+    let dtb_virt = phys_to_virt(dtb.into());
+    if let Some(dtb) = NonNull::new(dtb_virt.as_mut_ptr()) {
+        rdrive::init(rdrive::Platform::Fdt { addr: dtb }).unwrap();
+        rdrive::register_append(&driver_registers());
+        // rdrive::probe_pre_kernel().unwrap();
+    }
+}
+
+#[allow(unused)]
+/// maps a mmio physical address to a virtual address.
+fn iomap(addr: PhysAddr, size: usize) -> Result<NonNull<u8>, Box<dyn Error>> {
+    let end = (addr + size).align_up_4k();
+    let start = addr.align_down_4k();
+    let offset = addr - start;
+    let size = end - start;
+    let iomap = *IO_MAP_FUNC
+        .get()
+        .ok_or_else(|| "IO map function not initialized".to_string())?;
+
+    let virt = match iomap(start, size) {
+        Ok(val) => val,
+        Err(AxError::AlreadyExists) => phys_to_virt(start),
+        Err(e) => {
+            return Err(format!(
+                "Failed to map MMIO region: {e:?} (addr: {start:?}, size: {size:#x})"
+            )
+            .into());
+        }
+    };
+    let start_virt = virt + offset;
+    Ok(unsafe { NonNull::new_unchecked(start_virt.as_mut_ptr()) })
+}
+
+fn driver_registers() -> impl Deref<Target = [DriverRegister]> {
+    unsafe extern "C" {
+        fn __sdriver_register();
+        fn __edriver_register();
+    }
+
+    unsafe {
+        let len = __edriver_register as usize - __sdriver_register as usize;
+
+        if len == 0 {
+            return DriverRegisterSlice::empty();
+        }
+
+        let data = core::slice::from_raw_parts(__sdriver_register as _, len);
+
+        DriverRegisterSlice::from_raw(data)
+    }
+}

--- a/modules/axdriver/src/structs/dyn.rs
+++ b/modules/axdriver/src/structs/dyn.rs
@@ -1,7 +1,10 @@
 #![allow(unused_imports)]
 
+use core::{ops::Deref, ptr::NonNull};
+
 use crate::prelude::*;
 use alloc::{boxed::Box, vec, vec::Vec};
+use rdrive::register::{DriverRegister, DriverRegisterSlice};
 
 /// The unified type of the NIC devices.
 #[cfg(feature = "net")]
@@ -82,4 +85,20 @@ impl<D> Default for AxDeviceContainer<D> {
     fn default() -> Self {
         Self(Default::default())
     }
+}
+
+pub fn probe_all_devices() -> Vec<super::AxDeviceEnum> {
+    rdrive::probe_all(true).unwrap();
+    #[allow(unused_mut)]
+    let mut devices = Vec::new();
+    #[cfg(feature = "block")]
+    {
+        let ls = rdrive::get_list::<rdrive::driver::Block>();
+        for dev in ls {
+            devices.push(super::AxDeviceEnum::from_block(
+                crate::dyn_drivers::blk::Block::from(dev),
+            ));
+        }
+    }
+    devices
 }

--- a/modules/axhal/linker.lds.S
+++ b/modules/axhal/linker.lds.S
@@ -36,6 +36,11 @@ SECTIONS
         _sdata = .;
         *(.data.boot_page_table)
         . = ALIGN(4K);
+
+        __sdriver_register = .;
+        KEEP(*(.driver.register*))
+        __edriver_register = .;
+
         *(.data .data.*)
         *(.sdata .sdata.*)
         *(.got .got.*)

--- a/modules/axruntime/Cargo.toml
+++ b/modules/axruntime/Cargo.toml
@@ -18,6 +18,7 @@ tls = ["axhal/tls", "axtask?/tls"]
 alloc = ["axalloc"]
 paging = ["axhal/paging", "axmm"]
 ipi = ["dep:axipi"]
+driver-dyn = ["axdriver/dyn"]
 
 multitask = ["axtask/multitask"]
 fs = ["axdriver", "axfs"]
@@ -38,6 +39,7 @@ axdisplay = { workspace = true, optional = true }
 axtask = { workspace = true, optional = true }
 axipi = { workspace = true, optional = true }
 axplat = "0.2"
+axerrno = "0.1"
 
 crate_interface = "0.1"
 percpu = { version = "0.2", optional = true }

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -67,6 +67,7 @@ rtc = ["axfeat/rtc"]
 # Device drivers
 bus-mmio = ["axfeat/bus-mmio"]
 bus-pci = ["axfeat/bus-pci"]
+driver-dyn = ["axfeat/driver-dyn"]
 driver-ramdisk = ["axfeat/driver-ramdisk"]
 driver-ixgbe = ["axfeat/driver-ixgbe"]
 driver-fxmac = ["axfeat/driver-fxmac"]


### PR DESCRIPTION
fix: 优化错误处理格式，简化 MMIO 区域映射失败的错误信息

feat(axdriver): update rdrive dependency and add block driver support

- Updated rdrive dependency version from 0.14 to 0.14.4 in Cargo.toml.
- Introduced a new block driver module with implementations for block operations.
- Added virtio block driver support with MMIO transport.
- Refactored interrupt controller (GIC) driver probes to use OnProbeError for error handling.
- Enhanced dynamic driver probing to include block devices when the "block" feature is enabled.
- Improved error handling in block driver operations by mapping errors between driver and I/O layers.